### PR TITLE
cpuquiet: Set max CPUs from Power and Thermal profiles

### DIFF
--- a/drivers/cpuquiet/sysfs.c
+++ b/drivers/cpuquiet/sysfs.c
@@ -43,6 +43,9 @@ struct cpuquiet_dev {
 	struct kobject kobj;
 };
 
+unsigned int cpuquiet_nr_power_max_cpus;
+unsigned int cpuquiet_nr_thermal_max_cpus;
+
 static struct kobject *cpuquiet_global_kobject;
 static struct cpuquiet_dev *cpuquiet_cpu_devices[CONFIG_NR_CPUS];
 
@@ -121,17 +124,27 @@ static ssize_t show_nr_max_cpus(struct cpuquiet_attribute *cattr, char *buf)
 	return sprintf(buf, "%u\n", cpuquiet_nr_max_cpus);
 }
 
-static ssize_t store_nr_cpus(struct cpuquiet_attribute *cattr,
-					const char *buf, size_t count, bool max)
+static ssize_t show_nr_power_max_cpus(struct cpuquiet_attribute *cattr, char *buf)
+{
+	return sprintf(buf, "%u\n", cpuquiet_nr_power_max_cpus);
+}
+
+static ssize_t show_nr_thermal_max_cpus(struct cpuquiet_attribute *cattr, char *buf)
+{
+	return sprintf(buf, "%u\n", cpuquiet_nr_thermal_max_cpus);
+}
+
+static ssize_t store_nr_min_cpus(struct cpuquiet_attribute *cattr,
+					const char *buf, size_t count)
 {
 	ssize_t ret = 0;
-	unsigned int new_nr_cpus, new_min_cpus, new_max_cpus;
+	unsigned int new_min_cpus;
 
-	ret = sscanf(buf, "%u", &new_nr_cpus);
+	ret = sscanf(buf, "%u", &new_min_cpus);
 	if (ret != 1)
 		return -EINVAL;
 
-	if (new_nr_cpus < 1 || new_nr_cpus > num_present_cpus()) {
+	if (new_min_cpus < 1 || new_min_cpus > num_present_cpus()) {
 		pr_err("%s: CPU number limit must be in valid range [%d, %d]\n",
 					__func__, 1, num_present_cpus());
 		return -EINVAL;
@@ -139,25 +152,14 @@ static ssize_t store_nr_cpus(struct cpuquiet_attribute *cattr,
 
 	mutex_lock(&cpuquiet_min_max_cpus_lock);
 
-	if (max) {
-		new_min_cpus = cpuquiet_nr_min_cpus;
-		new_max_cpus = new_nr_cpus;
-	} else {
-		new_min_cpus = new_nr_cpus;
-		new_max_cpus = cpuquiet_nr_max_cpus;
-	}
-
-	if (new_max_cpus < new_min_cpus) {
-		pr_err("%s: nr_max_cpus cannot be less than nr_min_cpus\n",
-								__func__);
+	if (new_min_cpus > cpuquiet_nr_max_cpus) {
+		pr_err("%s: nr_min_cpus cannot be more than cpuquiet_nr_max_cpus\n",
+									__func__);
 		mutex_unlock(&cpuquiet_min_max_cpus_lock);
 		return -EINVAL;
 	}
 
-	if (max)
-		cpuquiet_nr_max_cpus = new_nr_cpus;
-	else
-		cpuquiet_nr_min_cpus = new_nr_cpus;
+	cpuquiet_nr_min_cpus = new_min_cpus;
 
 	mutex_unlock(&cpuquiet_min_max_cpus_lock);
 
@@ -166,29 +168,75 @@ static ssize_t store_nr_cpus(struct cpuquiet_attribute *cattr,
 	return ret;
 }
 
-static ssize_t store_nr_min_cpus(struct cpuquiet_attribute *cattr,
-					const char *buf, size_t count)
+static ssize_t store_nr_max_cpus(struct cpuquiet_attribute *cattr,
+					const char *buf, size_t count, bool thermal)
 {
-	return store_nr_cpus(cattr, buf, count, false);
+	ssize_t ret = 0;
+	unsigned int new_max_cpus;
+
+	ret = sscanf(buf, "%u", &new_max_cpus);
+	if (ret != 1)
+		return -EINVAL;
+
+	if (new_max_cpus < 1 || new_max_cpus > num_present_cpus()) {
+		pr_err("%s: CPU number limit must be in valid range [%d, %d]\n",
+					__func__, 1, num_present_cpus());
+		return -EINVAL;
+	}
+
+	mutex_lock(&cpuquiet_min_max_cpus_lock);
+
+	if (new_max_cpus < cpuquiet_nr_min_cpus) {
+		pr_err("%s: nr_max_cpus cannot be less than nr_min_cpus\n",
+								__func__);
+		mutex_unlock(&cpuquiet_min_max_cpus_lock);
+		return -EINVAL;
+	}
+
+	if (thermal)
+		cpuquiet_nr_thermal_max_cpus = new_max_cpus;
+	else
+		cpuquiet_nr_power_max_cpus = new_max_cpus;
+
+	if (cpuquiet_nr_thermal_max_cpus < cpuquiet_nr_power_max_cpus)
+		cpuquiet_nr_max_cpus = cpuquiet_nr_thermal_max_cpus;
+	else
+		cpuquiet_nr_max_cpus = cpuquiet_nr_power_max_cpus;
+
+	mutex_unlock(&cpuquiet_min_max_cpus_lock);
+
+	cpuquiet_queue_work();
+
+	return ret;
 }
 
-static ssize_t store_nr_max_cpus(struct cpuquiet_attribute *cattr,
+static ssize_t store_nr_power_max_cpus(struct cpuquiet_attribute *cattr,
 					const char *buf, size_t count)
 {
-	return store_nr_cpus(cattr, buf, count, true);
+	return store_nr_max_cpus(cattr, buf, count, false);
+}
+
+static ssize_t store_nr_thermal_max_cpus(struct cpuquiet_attribute *cattr,
+					const char *buf, size_t count)
+{
+	return store_nr_max_cpus(cattr, buf, count, true);
 }
 
 CPQ_ATTRIBUTE(current_governor, 0644, show_current_governor,
 			store_current_governor);
 CPQ_ATTRIBUTE(available_governors, 0444, show_available_governors, NULL);
 CPQ_ATTRIBUTE(nr_min_cpus, 0644, show_nr_min_cpus, store_nr_min_cpus);
-CPQ_ATTRIBUTE(nr_max_cpus, 0644, show_nr_max_cpus, store_nr_max_cpus);
+CPQ_ATTRIBUTE(nr_max_cpus, 0444, show_nr_max_cpus, NULL);
+CPQ_ATTRIBUTE(nr_power_max_cpus, 0644, show_nr_power_max_cpus, store_nr_power_max_cpus);
+CPQ_ATTRIBUTE(nr_thermal_max_cpus, 0644, show_nr_thermal_max_cpus, store_nr_thermal_max_cpus);
 
 static struct attribute *cpuquiet_default_attrs[] = {
 	&current_governor_attr.attr,
 	&available_governors_attr.attr,
 	&nr_min_cpus_attr.attr,
 	&nr_max_cpus_attr.attr,
+	&nr_power_max_cpus_attr.attr,
+	&nr_thermal_max_cpus_attr.attr,
 	NULL,
 };
 


### PR DESCRIPTION
There are two reasons we want to limit the number of active cores

* Power saving profile
* Thermal throttling

These two are independent, but with only a single sysfs to control
the number of active CPUs we can easily find that a power profile
has overridden more restrictive thermal limits.

This change adds two sysfs, one for power and one for thermal.
nr_max_cpus is now read only, taking its value from nr_power_max_cpus
unless nr_thermal_max_cpus is smaller.

Signed-off-by: Adam Farden <adam@farden.cz>