### PR TITLE
shinano: drivers: mmc: Fix card resume/initialization voltage

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -3311,6 +3311,11 @@ static int mmc_rescan_try_freq(struct mmc_host *host, unsigned freq)
 	 */
 	mmc_hw_reset_for_init(host);
 
+#ifdef CONFIG_MACH_SONY_SHINANO
+	/* The initialization should be done at 3.3 V I/O voltage. */
+	mmc_set_signal_voltage(host, MMC_SIGNAL_VOLTAGE_330);
+#endif
+
 	/*
 	 * sdio_reset sends CMD52 to reset card.  Since we do not know
 	 * if the card is being re-initialized, just send it.  CMD52

--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -1347,6 +1347,11 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
 	if (!mmc_host_is_spi(host))
 		mmc_set_bus_mode(host, MMC_BUSMODE_OPENDRAIN);
 
+#ifdef CONFIG_MACH_SONY_SHINANO
+	/* The initialization should be done at 3.3 V I/O voltage. */
+	mmc_set_signal_voltage(host, MMC_SIGNAL_VOLTAGE_330);
+#endif
+
 	/*
 	 * Since we're changing the OCR value, we seem to
 	 * need to tell some cards to go back to the idle

--- a/drivers/mmc/core/sd.c
+++ b/drivers/mmc/core/sd.c
@@ -1022,6 +1022,11 @@ static int mmc_sd_init_card(struct mmc_host *host, u32 ocr,
 	BUG_ON(!host);
 	WARN_ON(!host->claimed);
 
+#ifdef CONFIG_MACH_SONY_SHINANO
+	/* The initialization should be done at 3.3 V I/O voltage. */
+	mmc_set_signal_voltage(host, MMC_SIGNAL_VOLTAGE_330);
+#endif
+
 	err = mmc_sd_get_cid(host, ocr, cid, &rocr);
 	if (err)
 		return err;

--- a/drivers/mmc/core/sdio.c
+++ b/drivers/mmc/core/sdio.c
@@ -631,6 +631,11 @@ try_again:
 	 * Inform the card of the voltage
 	 */
 	if (!powered_resume) {
+#ifdef CONFIG_MACH_SONY_SHINANO
+		/* The initialization should be done at 3.3 V I/O voltage. */
+		mmc_set_signal_voltage(host, MMC_SIGNAL_VOLTAGE_330);
+#endif
+
 		err = mmc_send_io_op_cond(host, host->ocr, &ocr);
 		if (err)
 			goto err;
@@ -1094,6 +1099,12 @@ static int mmc_sdio_power_restore(struct mmc_host *host)
 	 * With these steps taken, mmc_select_voltage() is also required to
 	 * restore the correct voltage setting of the card.
 	 */
+
+#ifdef CONFIG_MACH_SONY_SHINANO
+	/* The initialization should be done at 3.3 V I/O voltage. */
+	if (!mmc_card_keep_power(host))
+		mmc_set_signal_voltage(host, MMC_SIGNAL_VOLTAGE_330);
+#endif
 
 	sdio_reset(host);
 	mmc_go_idle(host);


### PR DESCRIPTION
The card resume/initialization should be done at 3.3 V I/O voltage
for shinano devices.

These values was extracted from kernel-copyleft-23.4.A.0.x.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ib22585dba975c3d771b9cbc391bdeae1d9874747