### PR TITLE
Revert "drivers: spmi: Fix gcc warning"

### DIFF
--- a/drivers/spmi/spmi.c
+++ b/drivers/spmi/spmi.c
@@ -237,7 +237,7 @@ int spmi_add_device(struct spmi_device *spmidev)
 
 	/* Set the device name */
 	if (spmidev->res.resource)
-		dev_set_name(dev, "%02x-%s-%pa", spmidev->sid, spmidev->dev.of_node->name, &spmidev->res.resource[0].start);
+		dev_set_name(dev, "%02x-%s-%04x", spmidev->sid, spmidev->dev.of_node->name, spmidev->res.resource[0].start);
 	else
 		dev_set_name(dev, "%02x-%s", spmidev->sid, spmidev->dev.of_node->name);
 


### PR DESCRIPTION
this commit will break the sysfs device naming

This reverts commit 72adc78d3588760a7f893b6404efd84ef6784515.