### PR TITLE
camera: actuator: use vzalloc instead of kzalloc for init_settings

### DIFF
--- a/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
+++ b/drivers/media/platform/msm/camera_v2/sensor/actuator/msm_actuator.c
@@ -13,6 +13,7 @@
 #define pr_fmt(fmt) "%s:%d " fmt, __func__, __LINE__
 
 #include <linux/module.h>
+#include <linux/vmalloc.h>
 #include "msm_sd.h"
 #include "msm_actuator.h"
 #include "msm_cci.h"
@@ -1587,9 +1588,8 @@ static int32_t msm_actuator_set_param(struct msm_actuator_ctrl_t *a_ctrl,
 		set_info->actuator_params.init_setting_size
 		<= MAX_ACTUATOR_INIT_SET) {
 		if (a_ctrl->func_tbl->actuator_init_focus) {
-			init_settings = kzalloc(sizeof(struct reg_settings_t) *
-				(set_info->actuator_params.init_setting_size),
-				GFP_KERNEL);
+			init_settings = vzalloc(sizeof(struct reg_settings_t) *
+				(set_info->actuator_params.init_setting_size));
 			if (init_settings == NULL) {
 				kfree(a_ctrl->i2c_reg_tbl);
 				a_ctrl->i2c_reg_tbl = NULL;
@@ -1600,7 +1600,7 @@ static int32_t msm_actuator_set_param(struct msm_actuator_ctrl_t *a_ctrl,
 				(void *)set_info->actuator_params.init_settings,
 				set_info->actuator_params.init_setting_size *
 				sizeof(struct reg_settings_t))) {
-				kfree(init_settings);
+				vfree(init_settings);
 				kfree(a_ctrl->i2c_reg_tbl);
 				a_ctrl->i2c_reg_tbl = NULL;
 				pr_err("Error copying init_settings\n");
@@ -1609,7 +1609,7 @@ static int32_t msm_actuator_set_param(struct msm_actuator_ctrl_t *a_ctrl,
 			rc = a_ctrl->func_tbl->actuator_init_focus(a_ctrl,
 				set_info->actuator_params.init_setting_size,
 				init_settings);
-			kfree(init_settings);
+			vfree(init_settings);
 			init_settings = NULL;
 			if (rc < 0) {
 				kfree(a_ctrl->i2c_reg_tbl);


### PR DESCRIPTION
On devices with low RAM, high memory usage can lead to depletion of
CMA pages. Those CMA pages aren't reclaimed because compaction isn't
triggered for small allocations. This is exactly what happens when
trying to allocate memory for init_settings. The CMA pages are
depleted, and memory compaction isn't triggered because
size of init_settings is considered too small for that. This leads then
to a failed allocation that makes camera fail.
Avoid allocation errors for init_settings where by using virtually
contiguos memory. Since physically contiguos memory isn't strictly
required here, and vmalloc is largely left unused, this is safe to use.