### PR TITLE
drivers: serial_msm_hs: Fix BT FM

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -1443,11 +1443,6 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	mod_timer(&tx->tx_timeout_timer,
 		jiffies + msecs_to_jiffies(MSEC_PER_SEC));
 
-	/* Notify the bluesleep driver of outgoing data, if available. */
-#ifdef CONFIG_BT_MSM_SLEEP
-	bluesleep_outgoing_data();
-#endif
-
 	MSM_HS_DBG("%s:Enqueue Tx Cmd, ret %d\n", __func__, ret);
 }
 


### PR DESCRIPTION
This should be removed for BT FM until we find out the proper fix for
bluetooth (deep sleep state and BT timing for new paired device).

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I57f8cf46be50d4b40ef3c8d064facd6ef72a9515