### PR TITLE
cpufreq: interactive: fix memory leak

### DIFF
--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -2,6 +2,7 @@
  * drivers/cpufreq/cpufreq_interactive.c
  *
  * Copyright (C) 2010 Google, Inc.
+ * Copyright (c) 2012-2015, NVIDIA CORPORATION. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -1592,6 +1593,12 @@ static int cpufreq_governor_interactive(struct cpufreq_policy *policy,
 					get_sysfs_attr());
 			if (!have_governor_per_policy())
 				cpufreq_put_global_kobject();
+			if (tunables->above_hispeed_delay !=
+				default_above_hispeed_delay)
+				kfree(tunables->above_hispeed_delay);
+			if (tunables->target_loads != default_target_loads)
+				kfree(tunables->target_loads);
+			kfree(tunables);
 			common_tunables = NULL;
 		}
 


### PR DESCRIPTION
Memory leak from "above_hispeed_delay" and "target_loads" can occur if
cpu exit is called after sysfs write. This change fixes the leak by
freeing the 2 allocated arrays upon CPUFREQ_GOV_POLICY_EXIT.

Bug 200053544

Change-Id: If5612f58b0f92d777bea234cdc350a539d6c2c45
Signed-off-by: Mark Kuo <mkuo@nvidia.com>
Reviewed-on: http://git-master/r/654639
Reviewed-by: Automatic_Commit_Validation_User
Reviewed-by: Shridhar Rasal <srasal@nvidia.com>
Reviewed-by: Sachin Nikam <snikam@nvidia.com>
Reviewed-by: Bharat Nihalani <bnihalani@nvidia.com>
Tested-by: Bharat Nihalani <bnihalani@nvidia.com>